### PR TITLE
#36 Queue Dashboard FIXED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,3 +64,7 @@ JWT_EXPIRATION=7d
 # SMTP_PORT=587
 # SMTP_USER=
 # SMTP_PASS=
+
+# ─── BullMQ Dashboard ───────────────────────────────────
+# Visit http://localhost:${PORT}/admin/queues to monitor and manage jobs.
+BULL_BOARD_PATH=/admin/queues

--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ QUEUE_CONCURRENCY=5
 JOB_ATTEMPTS=3
 JOB_BACKOFF_DELAY=5000
 
+# BullMQ Dashboard
+# Visit http://localhost:${PORT}/admin/queues to monitor active, completed, and failed jobs.
+BULL_BOARD_PATH=/admin/queues
+
 # Monitoring (Optional)
 SENTRY_DSN=
 LOG_LEVEL=debug                   # debug | info | warn | error

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "license": "UNLICENSED",
       "dependencies": {
+        "@bull-board/api": "^8.0.1",
+        "@bull-board/express": "^8.0.1",
         "@nest-lab/throttler-storage-redis": "^1.2.0",
         "@nestjs/bull": "^11.0.4",
         "@nestjs/bullmq": "^11.0.4",
@@ -739,6 +741,39 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@bull-board/api": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@bull-board/api/-/api-8.0.1.tgz",
+      "integrity": "sha512-7FELJHRQPtjH9+r/DUArr4pDVU8r1yeDS9azQUzFtIbsUT5xGjyg5R1RB0I/RfwFfK5bqho/4cpzxJ/UnQjSKA==",
+      "license": "MIT",
+      "dependencies": {
+        "redis-info": "^3.1.0"
+      },
+      "peerDependencies": {
+        "@bull-board/ui": "8.0.1"
+      }
+    },
+    "node_modules/@bull-board/express": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@bull-board/express/-/express-8.0.1.tgz",
+      "integrity": "sha512-VOEhLNlaaVk3mBBoREXO/Dopzr9rKK5TpOGyaCbcnpzLKlrlwhj6BAeWWreB7/3Wu+pNnbKmrAhK8OOnYdzxLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bull-board/api": "8.0.1",
+        "@bull-board/ui": "8.0.1",
+        "ejs": "^6.0.1",
+        "express": "^5.2.1"
+      }
+    },
+    "node_modules/@bull-board/ui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@bull-board/ui/-/ui-8.0.1.tgz",
+      "integrity": "sha512-gKEGSD8dlUoWFGJJ4I4Q5bDtfB7yJwGfpgA2DVn1G1TzlUSN5n4fzzcGpLf5fS+QhR7tB/niydUiFRQ2zrjVrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bull-board/api": "8.0.1"
       }
     },
     "node_modules/@clack/core": {
@@ -6628,6 +6663,18 @@
         "fast-check": "^3.23.1"
       }
     },
+    "node_modules/ejs": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-6.0.1.tgz",
+      "integrity": "sha512-UaaM14yby8U3k02ihS1Bmj5Kz2d7CCQM1scxpgs4Mhkq8F1wR2gl3+Ts4h5Ne4Mnt7M9m4Dw7jsuMr3+xO4vZA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.12.18"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
@@ -10822,6 +10869,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/redis-info": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redis-info/-/redis-info-3.1.0.tgz",
+      "integrity": "sha512-ER4L9Sh/vm63DkIE0bkSjxluQlioBiBgf5w1UuldaW/3vPcecdljVDisZhmnCMvsxHNiARTTDDHGg9cGwTfrKg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.11"
       }
     },
     "node_modules/redis-parser": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "seed": "npx prisma db seed"
   },
   "dependencies": {
+    "@bull-board/api": "^8.0.1",
+    "@bull-board/express": "^8.0.1",
     "@nest-lab/throttler-storage-redis": "^1.2.0",
     "@nestjs/bull": "^11.0.4",
     "@nestjs/bullmq": "^11.0.4",

--- a/src/jobs/dashboard /bull-board.ts
+++ b/src/jobs/dashboard /bull-board.ts
@@ -1,0 +1,37 @@
+import { INestApplication } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createBullBoard } from '@bull-board/api';
+import { BullMQAdapter } from '@bull-board/api/bullMQAdapter';
+import { ExpressAdapter } from '@bull-board/express';
+import { NotificationQueueService } from '../services/notification-queue.service';
+
+export const DEFAULT_BULL_BOARD_PATH = '/admin/queues';
+
+/**
+ * Mounts Bull Board on the existing Nest/Express application.
+ *
+ * Bull Board provides a dashboard for queue monitoring and job management,
+ * including viewing active/completed/failed jobs, inspecting payloads/logs,
+ * and retrying failed jobs.
+ */
+export function setupBullBoard(app: INestApplication): void {
+  const configService = app.get(ConfigService);
+  const notificationQueueService = app.get(NotificationQueueService);
+  const bullBoardPath =
+    configService.get<string>('BULL_BOARD_PATH') ?? DEFAULT_BULL_BOARD_PATH;
+
+  const serverAdapter = new ExpressAdapter();
+  serverAdapter.setBasePath(bullBoardPath);
+
+  createBullBoard({
+    queues: [new BullMQAdapter(notificationQueueService.getQueue())],
+    serverAdapter,
+    options: {
+      uiConfig: {
+        boardTitle: 'Pet Adoption Queue Dashboard',
+      },
+    },
+  });
+
+  app.use(bullBoardPath, serverAdapter.getRouter());
+}

--- a/src/jobs/services/notification-queue.service.ts
+++ b/src/jobs/services/notification-queue.service.ts
@@ -45,6 +45,10 @@ export class NotificationQueueService implements OnModuleDestroy {
     );
   }
 
+  getQueue(): Queue<SendTransactionalEmailJobInput> {
+    return this.queue;
+  }
+
   async onModuleDestroy(): Promise<void> {
     await this.queue.close();
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
 import { AppLogger } from './common/logger/logger.service';
 import { ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { setupBullBoard } from './jobs/dashboard/bull-board';
 
 // This bootstrap function is like aFactory that builds our NestJS app - it creates,
 // configures, and starts the entire application server, making it ready to handle requests.
@@ -50,6 +51,8 @@ app.useGlobalFilters(
   const document = SwaggerModule.createDocument(app, config);
 
   SwaggerModule.setup('api/docs', app, document);
+
+  setupBullBoard(app);
 
   await app.listen(port, '0.0.0.0');
 


### PR DESCRIPTION
#36 Queue Dashboard

Project overview
The repository is a NestJS backend for a pet adoption platform. It includes modules for:
auth
users
pets
adoption
custody
escrow
events
email
jobs
health
logging
prisma
cloudinary
stellar

The backend uses:
NestJS
Prisma
PostgreSQL
Redis
BullMQ
JWT auth
Swagger
Nodemailer
Cloudinary

2. Relevant issue
The issue requested:
Set up a dashboard to monitor and manage BullMQ queues and job statuses.
Acceptance criteria:
Dashboard is accessible and displays active, completed, and failed jobs.
Jobs can be inspected and retried from the dashboard.
Dependency: BullMQ setup.

3. Existing BullMQ setup found
The codebase already had a BullMQ setup under:
src/jobs/
Important existing files:
src/jobs/jobs.module.ts
src/jobs/queues/queue.config.ts
src/jobs/services/notification-queue.service.ts
src/jobs/processors/notification.processor.ts
src/jobs/workers/notification.worker.ts
The existing queue is:
notifications
Defined in:
export const NOTIFICATION_QUEUE_NAME = 'notifications';
The queue currently processes transactional email jobs:
send_transactional_email
So the backend already had queue creation, workers, retry attempts, backoff, and Redis connection configuration.

4. Main gap found
The codebase had BullMQ queues and workers, but it did not have a dashboard/UI to inspect or manage jobs.
There was no Bull Board, Arena, or other queue dashboard mounted in the NestJS application.
So the exact missing feature was:
No accessible BullMQ queue management dashboard.

5. Fix implemented
I added Bull Board to expose a dashboard for the existing BullMQ notification queue.
The dashboard is mounted at:
/admin/queues
Default local URL:
http://localhost:3000/admin/queues
or depending on the configured port:
http://localhost:${PORT}/admin/queues

6. What the dashboard provides
The Bull Board dashboard allows users/developers to:
View active jobs
View completed jobs
View failed jobs
Inspect job payloads and metadata
Inspect job status
Retry failed jobs
Pause/resume queue where supported
View queue counts and queue details
This satisfies the issue acceptance criteria.

7. Files created
src/jobs/dashboard/bull-board.ts
This file contains the dashboard setup logic.
It imports Bull Board, connects it to the existing NotificationQueueService, and mounts the dashboard router.

8. Files modified
.env.example
README.md
package.json
package-lock.json
src/main.ts
src/jobs/services/notification-queue.service.ts

9. Important code changes
src/main.ts
The Bull Board setup is mounted during application bootstrap:
setupBullBoard(app);
src/jobs/services/notification-queue.service.ts
Added a method to expose the existing BullMQ queue instance:
getQueue(): Queue<SendTransactionalEmailJobInput> {
  return this.queue;
}
This lets the dashboard use the same queue instance already used by the app.
src/jobs/dashboard/bull-board.ts
Created the Bull Board setup:
createBullBoard({
  queues: [new BullMQAdapter(notificationQueueService.getQueue())],
  serverAdapter,
  options: {
    uiConfig: {
      boardTitle: 'Pet Adoption Queue Dashboard',
    },
  },
});
package.json
Added:
"@bull-board/api": "^8.0.1",
"@bull-board/express": "^8.0.1"
.env.example
Added:
env
BULL_BOARD_PATH=/admin/queues
README.md
Documented the BullMQ dashboard path.
CLOSED #36

