### PR TITLE
Fix: #P3-19 — Event Replay: Replay Events for a Single Aggregate (Auto-Generated)

### DIFF
--- a/src/events/events.service.spec.ts
+++ b/src/events/events.service.spec.ts
@@ -1,20 +1,23 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { EventsService } from './events.service';
+import {
+  adoptionReducer,
+  EventsService,
+  EventLedger,
+} from './events.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { EventEntityType, EventType } from '@prisma/client';
 
 describe('EventsService', () => {
   let service: EventsService;
 
-  // 1. Create a strongly typed mock object
   const mockPrismaService = {
     eventLog: {
       create: jest.fn(),
+      findMany: jest.fn(),
     },
   };
 
   beforeEach(async () => {
-    // Clear mocks between tests to prevent state leakage
     jest.clearAllMocks();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -54,12 +57,88 @@ describe('EventsService', () => {
         entityType: mockDto.entityType,
         entityId: mockDto.entityId,
         eventType: mockDto.eventType,
-        actorId: undefined, // These will be undefined since they aren't in mockDto
+        actorId: undefined,
         txHash: undefined,
         blockHeight: undefined,
         payload: mockDto.payload,
         metadata: undefined,
       },
+    });
+  });
+
+  it('replays three adoption events in sequence order', async () => {
+    const events: EventLedger[] = [
+      {
+        entityType: EventEntityType.ADOPTION,
+        entityId: 'adoption-123',
+        eventType: 'ADOPTION_REQUESTED',
+        sequenceNumber: 1,
+        payload: { adopterId: 'user-123', petId: 'pet-123' },
+      },
+      {
+        entityType: EventEntityType.ADOPTION,
+        entityId: 'adoption-123',
+        eventType: 'ADOPTION_APPROVED',
+        sequenceNumber: 2,
+        payload: { approvedBy: 'admin-123' },
+      },
+      {
+        entityType: EventEntityType.ADOPTION,
+        entityId: 'adoption-123',
+        eventType: 'ADOPTION_COMPLETED',
+        sequenceNumber: 3,
+        payload: { completedAt: '2026-07-28T00:00:00.000Z' },
+      },
+    ];
+
+    mockPrismaService.eventLog.findMany.mockResolvedValue(events);
+
+    const state = await service.replayAggregate(
+      EventEntityType.ADOPTION,
+      'adoption-123',
+    );
+
+    expect(mockPrismaService.eventLog.findMany).toHaveBeenCalledWith({
+      where: {
+        entityType: EventEntityType.ADOPTION,
+        entityId: 'adoption-123',
+      },
+      orderBy: {
+        sequenceNumber: 'asc',
+      },
+    });
+    expect(state).toEqual({
+      adopterId: 'user-123',
+      petId: 'pet-123',
+      approvedBy: 'admin-123',
+      completedAt: '2026-07-28T00:00:00.000Z',
+      status: 'COMPLETED',
+    });
+  });
+
+  it('applies adoption events one at a time through the reducer', () => {
+    const initialState = { status: 'NEW' };
+    const requested: EventLedger = {
+      entityType: EventEntityType.ADOPTION,
+      entityId: 'adoption-123',
+      eventType: 'ADOPTION_REQUESTED',
+      payload: { petId: 'pet-123' },
+    };
+    const approved: EventLedger = {
+      entityType: EventEntityType.ADOPTION,
+      entityId: 'adoption-123',
+      eventType: 'ADOPTION_APPROVED',
+      payload: { approvedBy: 'admin-123' },
+    };
+
+    const pending = adoptionReducer(initialState, requested);
+    const finalState = adoptionReducer(pending, approved);
+
+    expect(pending).toEqual({ petId: 'pet-123', status: 'PENDING' });
+    expect(finalState).toEqual({
+      petId: 'pet-123',
+      approvedBy: 'admin-123',
+      status: 'APPROVED',
     });
   });
 });

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -13,6 +13,103 @@ export interface CreateEventLogDto {
   metadata?: Prisma.InputJsonValue;
 }
 
+export interface EventLedger {
+  entityType: EventEntityType | string;
+  entityId: string;
+  eventType: EventType | string;
+  payload: Prisma.JsonValue;
+  sequenceNumber?: number;
+  [key: string]: unknown;
+}
+
+export type AggregateState = Record<string, unknown>;
+
+type JsonObject = Record<string, unknown>;
+
+function asObject(value: Prisma.JsonValue): JsonObject {
+  if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as JsonObject;
+  }
+  return {};
+}
+
+function reduceLifecycleState(
+  state: AggregateState,
+  event: EventLedger,
+  statusByEvent: Record<string, string>,
+): AggregateState {
+  const payload = asObject(event.payload);
+  const status = statusByEvent[String(event.eventType)];
+
+  return {
+    ...state,
+    ...payload,
+    ...(status ? { status } : {}),
+  };
+}
+
+export function adoptionReducer(
+  state: AggregateState,
+  event: EventLedger,
+): AggregateState {
+  return reduceLifecycleState(state, event, {
+    ADOPTION_REQUESTED: 'PENDING',
+    ADOPTION_APPROVED: 'APPROVED',
+    ADOPTION_REJECTED: 'REJECTED',
+    ADOPTION_COMPLETED: 'COMPLETED',
+    ADOPTION_CANCELLED: 'CANCELLED',
+  });
+}
+
+export function petReducer(
+  state: AggregateState,
+  event: EventLedger,
+): AggregateState {
+  return reduceLifecycleState(state, event, {
+    PET_CREATED: 'AVAILABLE',
+    PET_STATUS_CHANGED: String(asObject(event.payload).status ?? ''),
+    PET_ADOPTED: 'ADOPTED',
+    PET_RETURNED: 'AVAILABLE',
+  });
+}
+
+export function custodyReducer(
+  state: AggregateState,
+  event: EventLedger,
+): AggregateState {
+  return reduceLifecycleState(state, event, {
+    CUSTODY_REQUESTED: 'PENDING',
+    CUSTODY_APPROVED: 'APPROVED',
+    CUSTODY_STARTED: 'ACTIVE',
+    CUSTODY_COMPLETED: 'COMPLETED',
+    CUSTODY_CANCELLED: 'CANCELLED',
+  });
+}
+
+export function escrowReducer(
+  state: AggregateState,
+  event: EventLedger,
+): AggregateState {
+  return reduceLifecycleState(state, event, {
+    ESCROW_CREATED: 'CREATED',
+    ESCROW_FUNDED: 'FUNDED',
+    ESCROW_RELEASED: 'RELEASED',
+    ESCROW_REFUNDED: 'REFUNDED',
+    ESCROW_CANCELLED: 'CANCELLED',
+  });
+}
+
+export function userReducer(
+  state: AggregateState,
+  event: EventLedger,
+): AggregateState {
+  return reduceLifecycleState(state, event, {
+    USER_REGISTERED: 'ACTIVE',
+    USER_ACTIVATED: 'ACTIVE',
+    USER_DEACTIVATED: 'INACTIVE',
+  });
+}
+
 @Injectable()
 export class EventsService {
   private readonly logger = new Logger(EventsService.name);
@@ -47,6 +144,50 @@ export class EventsService {
         error instanceof Error ? error.stack : String(error),
       );
       throw error;
+    }
+  }
+
+  /**
+   * Reconstructs an aggregate by applying its ledger events in sequence order.
+   */
+  async replayAggregate<T extends AggregateState>(
+    entityType: EventEntityType,
+    entityId: string,
+    initialState = {} as T,
+  ): Promise<T> {
+    const events = (await this.prisma.eventLog.findMany({
+      where: {
+        entityType,
+        entityId,
+      },
+      orderBy: {
+        sequenceNumber: 'asc',
+      } as never,
+    })) as unknown as EventLedger[];
+
+    const reducer = this.getReducer(entityType);
+    return events.reduce<AggregateState>(
+      (state, event) => reducer(state, event),
+      initialState,
+    ) as T;
+  }
+
+  private getReducer(
+    entityType: EventEntityType,
+  ): (state: AggregateState, event: EventLedger) => AggregateState {
+    switch (String(entityType).toUpperCase()) {
+      case 'ADOPTION':
+        return adoptionReducer;
+      case 'PET':
+        return petReducer;
+      case 'CUSTODY':
+        return custodyReducer;
+      case 'ESCROW':
+        return escrowReducer;
+      case 'USER':
+        return userReducer;
+      default:
+        return (state, event) => ({ ...state, ...asObject(event.payload) });
     }
   }
 }


### PR DESCRIPTION
Closes #141

This PR was generated by the DripTide AI coder and scoped strictly to issue #141.

### Changes
Added aggregate event replay support to EventsService, including sequence-ordered event retrieval, reducers for adoption, pet, custody, escrow, and user aggregates, and a generic fallback reducer. Added unit tests covering three-event adoption replay and stepwise reducer behavior.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #141` so the Drips Wave bot resolves the issue on merge._