### PR TITLE
Fix: #P3-20 — Event Replay: Rebuild Adoption State from Events (Auto-Generated)

### DIFF
--- a/src/events/adoption.reducer.spec.ts
+++ b/src/events/adoption.reducer.spec.ts
@@ -1,0 +1,84 @@
+import {
+  adoptionReducer,
+  ReplayedAdoptionState,
+} from './adoption.reducer';
+
+describe('adoptionReducer', () => {
+  const initialState: ReplayedAdoptionState = {
+    status: 'INITIALIZED',
+    adopterId: '',
+    petId: '',
+  };
+
+  it('rebuilds the complete adoption lifecycle', () => {
+    const requested = adoptionReducer(initialState, {
+      eventType: 'ADOPTION_REQUESTED',
+      payload: {
+        adopterId: 'adopter-1',
+        petId: 'pet-1',
+      },
+    });
+
+    const approved = adoptionReducer(requested, {
+      eventType: 'ADOPTION_APPROVED',
+      payload: {
+        approvedBy: 'admin-1',
+      },
+    });
+
+    const escrowCreated = adoptionReducer(approved, {
+      eventType: 'ADOPTION_ESCROW_CREATED',
+      payload: {
+        escrowAccountId: 'escrow-1',
+      },
+    });
+
+    const escrowFunded = adoptionReducer(escrowCreated, {
+      eventType: 'ADOPTION_ESCROW_FUNDED',
+      txHash: 'tx-1',
+      payload: {},
+    });
+
+    const completed = adoptionReducer(escrowFunded, {
+      eventType: 'ADOPTION_COMPLETED',
+      payload: {
+        completedAt: '2026-01-01T00:00:00.000Z',
+      },
+    });
+
+    expect(completed).toEqual({
+      status: 'COMPLETED',
+      adopterId: 'adopter-1',
+      petId: 'pet-1',
+      approvedBy: 'admin-1',
+      escrowAccountId: 'escrow-1',
+      escrowTxHash: 'tx-1',
+      completedAt: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('logs and passes through unknown events unchanged', () => {
+    const warnSpy = jest
+      .spyOn((require('@nestjs/common').Logger.prototype as { warn: jest.Mock }), 'warn')
+      .mockImplementation(() => undefined);
+
+    const state = {
+      ...initialState,
+      status: 'APPROVED',
+      adopterId: 'adopter-1',
+      petId: 'pet-1',
+    };
+
+    const result = adoptionReducer(state, {
+      eventType: 'ADOPTION_UNKNOWN',
+      payload: { ignored: true },
+    });
+
+    expect(result).toBe(state);
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Unknown adoption event type: ADOPTION_UNKNOWN',
+    );
+
+    warnSpy.mockRestore();
+  });
+});

--- a/src/events/adoption.reducer.ts
+++ b/src/events/adoption.reducer.ts
@@ -1,0 +1,132 @@
+import { Logger } from '@nestjs/common';
+
+export interface ReplayedAdoptionState {
+  status: string;
+  adopterId: string;
+  petId: string;
+  approvedBy?: string;
+  escrowAccountId?: string;
+  escrowTxHash?: string;
+  completedAt?: string;
+}
+
+export interface AdoptionReplayEvent {
+  eventType: string;
+  actorId?: string | null;
+  txHash?: string | null;
+  createdAt?: string | Date | null;
+  payload?: unknown;
+}
+
+const logger = new Logger('AdoptionReducer');
+
+type EventPayload = Record<string, unknown>;
+
+function getPayload(event: AdoptionReplayEvent): EventPayload {
+  if (event.payload !== null && typeof event.payload === 'object') {
+    return event.payload as EventPayload;
+  }
+
+  return {};
+}
+
+function getString(
+  payload: EventPayload,
+  ...keys: string[]
+): string | undefined {
+  for (const key of keys) {
+    const value = payload[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return undefined;
+}
+
+function getEventTimestamp(event: AdoptionReplayEvent): string | undefined {
+  if (typeof event.createdAt === 'string') {
+    return event.createdAt;
+  }
+
+  if (event.createdAt instanceof Date) {
+    return event.createdAt.toISOString();
+  }
+
+  return undefined;
+}
+
+/**
+ * Rebuilds adoption state by applying adoption events in event-log order.
+ * Unknown events are deliberately ignored so unrelated events can safely be
+ * replayed against an adoption aggregate.
+ */
+export function adoptionReducer(
+  state: ReplayedAdoptionState,
+  event: AdoptionReplayEvent,
+): ReplayedAdoptionState {
+  const payload = getPayload(event);
+
+  switch (event.eventType) {
+    case 'ADOPTION_REQUESTED': {
+      const adopterId = getString(payload, 'adopterId', 'userId') ?? state.adopterId;
+      const petId = getString(payload, 'petId') ?? state.petId;
+
+      return {
+        ...state,
+        status: 'REQUESTED',
+        adopterId,
+        petId,
+      };
+    }
+
+    case 'ADOPTION_APPROVED':
+      return {
+        ...state,
+        status: 'APPROVED',
+        approvedBy:
+          getString(payload, 'approvedBy', 'adminId', 'actorId') ??
+          event.actorId ??
+          state.approvedBy,
+      };
+
+    case 'ADOPTION_REJECTED':
+      return {
+        ...state,
+        status: 'REJECTED',
+      };
+
+    case 'ADOPTION_ESCROW_CREATED':
+      return {
+        ...state,
+        status: 'ESCROW_CREATED',
+        escrowAccountId:
+          getString(payload, 'escrowAccountId', 'accountId') ??
+          state.escrowAccountId,
+      };
+
+    case 'ADOPTION_ESCROW_FUNDED':
+      return {
+        ...state,
+        status: 'ESCROW_FUNDED',
+        escrowTxHash:
+          getString(payload, 'escrowTxHash', 'txHash') ??
+          event.txHash ??
+          state.escrowTxHash,
+      };
+
+    case 'ADOPTION_COMPLETED':
+      return {
+        ...state,
+        status: 'COMPLETED',
+        completedAt:
+          getString(payload, 'completedAt', 'timestamp') ??
+          getEventTimestamp(event) ??
+          state.completedAt,
+      };
+
+    default:
+      logger.warn(`Unknown adoption event type: ${event.eventType}`);
+      return state;
+  }
+}


### PR DESCRIPTION
Closes #142

This PR was generated by the DripTide AI coder and scoped strictly to issue #142.

### Changes
Added an adoption event reducer handling all six adoption event types, preserving relevant adopter, pet, approval, escrow, transaction, and completion metadata. Added unit tests for the complete lifecycle and unknown-event logging/pass-through behavior.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #142` so the Drips Wave bot resolves the issue on merge._