### PR TITLE
Fix: #P3-6 — Event Sourcing: Sequence Numbers Per Aggregate (Auto-Generated)

### DIFF
--- a/src/events/event-ledger.controller.ts
+++ b/src/events/event-ledger.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, Param, UseGuards } from '@nestjs/common';
+import { EventLedgerService } from './event-ledger.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { Role } from '../auth/enums/role.enum';
+
+@Controller('admin/event-ledger')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(Role.ADMIN)
+export class EventLedgerController {
+  constructor(private readonly eventLedgerService: EventLedgerService) {}
+
+  @Get(':aggregateId/integrity')
+  async checkIntegrity(@Param('aggregateId') aggregateId: string) {
+    const gaps = await this.eventLedgerService.detectGaps(aggregateId);
+
+    return {
+      aggregateId,
+      valid: gaps.length === 0,
+      gaps,
+    };
+  }
+}

--- a/src/events/event-ledger.service.spec.ts
+++ b/src/events/event-ledger.service.spec.ts
@@ -1,0 +1,73 @@
+import { EventEntityType, EventType } from '@prisma/client';
+import { EventLedgerService } from './event-ledger.service';
+
+describe('EventLedgerService', () => {
+  const events: Array<Record<string, unknown>> = [];
+  const transaction = {
+    $executeRaw: jest.fn().mockResolvedValue(0),
+    eventLog: {
+      findFirst: jest.fn(async () => {
+        const aggregateEvents = events.filter(
+          (event) => event.entityId === 'aggregate-1',
+        );
+        const latest = aggregateEvents.reduce<number | null>(
+          (maximum, event) =>
+            typeof event.sequenceNumber === 'number' &&
+            (maximum === null || event.sequenceNumber > maximum)
+              ? event.sequenceNumber
+              : maximum,
+          null,
+        );
+
+        return latest === null ? null : { sequenceNumber: latest };
+      }),
+      create: jest.fn(async ({ data }: { data: Record<string, unknown> }) => {
+        const event = { id: String(events.length + 1), ...data };
+        events.push(event);
+        return event;
+      }),
+    },
+  };
+
+  const prisma = {
+    $transaction: jest.fn(
+      async (callback: (client: typeof transaction) => unknown) =>
+        callback(transaction),
+    ),
+    eventLog: {
+      findMany: jest.fn(),
+    },
+  };
+
+  let service: EventLedgerService;
+
+  beforeEach(() => {
+    events.length = 0;
+    jest.clearAllMocks();
+    service = new EventLedgerService(prisma as never);
+  });
+
+  it('assigns sequences 1 through 5 when five events are appended', async () => {
+    for (let index = 0; index < 5; index += 1) {
+      await service.appendEvent({
+        entityType: EventEntityType.ADOPTION,
+        aggregateId: 'aggregate-1',
+        eventType: EventType.ADOPTION_REQUESTED,
+        payload: {},
+      });
+    }
+
+    expect(events.map((event) => event.sequenceNumber)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('detects missing sequence numbers', async () => {
+    prisma.eventLog.findMany.mockResolvedValue([
+      { sequenceNumber: 1 },
+      { sequenceNumber: 2 },
+      { sequenceNumber: 4 },
+      { sequenceNumber: 6 },
+    ]);
+
+    await expect(service.detectGaps('aggregate-1')).resolves.toEqual([3, 5]);
+  });
+});

--- a/src/events/event-ledger.service.ts
+++ b/src/events/event-ledger.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@nestjs/common';
+import { EventType, EventEntityType, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateEventLogDto } from './events.service';
+
+export interface AppendEventDto {
+  entityType: EventEntityType;
+  aggregateId: string;
+  eventType: EventType;
+  actorId?: string;
+  txHash?: string;
+  blockHeight?: number;
+  payload: Prisma.InputJsonValue;
+  metadata?: Prisma.InputJsonValue;
+}
+
+@Injectable()
+export class EventLedgerService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Returns the next one-based sequence number for an aggregate.
+   *
+   * The aggregate is protected by a PostgreSQL transaction-scoped advisory
+   * lock so concurrent writers for the same aggregate serialize while writers
+   * for different aggregates remain independent.
+   */
+  async getNextSequenceNumber(aggregateId: string): Promise<number> {
+    return this.prisma.$transaction(async (transaction) => {
+      await transaction.$executeRaw`
+        SELECT pg_advisory_xact_lock(hashtext(${aggregateId}))
+      `;
+
+      const eventLog = transaction.eventLog as any;
+      const latestEvent = await eventLog.findFirst({
+        where: {
+          entityId: aggregateId,
+        },
+        orderBy: {
+          sequenceNumber: 'desc',
+        },
+        select: {
+          sequenceNumber: true,
+        },
+      });
+
+      return (latestEvent?.sequenceNumber ?? 0) + 1;
+    });
+  }
+
+  /**
+   * Appends an event and allocates its sequence in the same transaction.
+   */
+  async appendEvent(dto: AppendEventDto | CreateEventLogDto) {
+    const aggregateId = 'aggregateId' in dto ? dto.aggregateId : dto.entityId;
+
+    return this.prisma.$transaction(async (transaction) => {
+      await transaction.$executeRaw`
+        SELECT pg_advisory_xact_lock(hashtext(${aggregateId}))
+      `;
+
+      const eventLog = transaction.eventLog as any;
+      const latestEvent = await eventLog.findFirst({
+        where: {
+          entityId: aggregateId,
+        },
+        orderBy: {
+          sequenceNumber: 'desc',
+        },
+        select: {
+          sequenceNumber: true,
+        },
+      });
+
+      const sequenceNumber = (latestEvent?.sequenceNumber ?? 0) + 1;
+      const event = await eventLog.create({
+        data: {
+          entityType: dto.entityType,
+          entityId: aggregateId,
+          eventType: dto.eventType,
+          actorId: dto.actorId,
+          txHash: dto.txHash,
+          blockHeight: dto.blockHeight,
+          payload: dto.payload,
+          metadata: dto.metadata,
+          sequenceNumber,
+        },
+      });
+
+      return event;
+    });
+  }
+
+  /**
+   * Returns all missing sequence numbers from one through the aggregate's
+   * highest committed sequence number.
+   */
+  async detectGaps(aggregateId: string): Promise<number[]> {
+    const eventLog = this.prisma.eventLog as any;
+    const events = await eventLog.findMany({
+      where: {
+        entityId: aggregateId,
+      },
+      orderBy: {
+        sequenceNumber: 'asc',
+      },
+      select: {
+        sequenceNumber: true,
+      },
+    });
+
+    const sequences = events
+      .map((event: { sequenceNumber?: unknown }) => event.sequenceNumber)
+      .filter(
+        (sequence: unknown): sequence is number =>
+          Number.isInteger(sequence) && (sequence as number) > 0,
+      );
+
+    const highestSequence = sequences.length > 0 ? Math.max(...sequences) : 0;
+    const presentSequences = new Set(sequences);
+    const gaps: number[] = [];
+
+    for (let sequence = 1; sequence <= highestSequence; sequence += 1) {
+      if (!presentSequences.has(sequence)) {
+        gaps.push(sequence);
+      }
+    }
+
+    return gaps;
+  }
+}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,12 +1,15 @@
 import { Global, Module } from '@nestjs/common';
 import { EventsService } from './events.service';
+import { EventLedgerService } from './event-ledger.service';
+import { EventLedgerController } from './event-ledger.controller';
 import { PrismaModule } from '../prisma/prisma.module';
 
-@Global() // Makes EventsService available application-wide without needing to import EventsModule everywhere
+@Global()
 @Module({
   imports: [PrismaModule],
-  providers: [EventsService],
-  exports: [EventsService], // Export it so other modules can use it
+  controllers: [EventLedgerController],
+  providers: [EventsService, EventLedgerService],
+  exports: [EventsService, EventLedgerService],
 })
 export class EventsModule {}
 


### PR DESCRIPTION
Closes #128

This PR was generated by the DripTide AI coder and scoped strictly to issue #128.

### Changes
Added EventLedgerService with transaction-scoped advisory locking, atomic sequence allocation during event append, gap detection, and support for checking aggregate integrity. Added an admin-only integrity endpoint, registered the service and controller in EventsModule, and added unit tests covering sequences 1 through 5 and missing sequence detection.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #128` so the Drips Wave bot resolves the issue on merge._