### PR TITLE
Fix: #P3-4 — Event Sourcing: EventLedgerService — appendEvent() Core Method (Auto-Generated)

### DIFF
--- a/src/event-ledger/event-ledger.service.ts
+++ b/src/event-ledger/event-ledger.service.ts
@@ -1,0 +1,103 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+export enum AggregateType {
+  ADOPTION = 'ADOPTION',
+  CUSTODY = 'CUSTODY',
+  PET = 'PET',
+  USER = 'USER',
+}
+
+export interface EventLedger {
+  id?: string;
+  aggregateType: AggregateType | string;
+  aggregateId: string;
+  sequenceNumber: number;
+  eventType: string;
+  payload: Record<string, unknown>;
+  recordedBy?: string | null;
+  recordedAt?: Date;
+  [key: string]: unknown;
+}
+
+export interface AppendEventParams {
+  aggregateType: AggregateType;
+  aggregateId: string;
+  eventType: string;
+  payload: Record<string, unknown>;
+  recordedBy?: string;
+}
+
+export interface AnchoringQueue {
+  add(
+    jobName: string,
+    data: {
+      eventId?: string;
+      aggregateType: AggregateType | string;
+      aggregateId: string;
+      sequenceNumber: number;
+    },
+  ): Promise<unknown>;
+}
+
+export const ANCHORING_QUEUE = 'EVENT_LEDGER_ANCHORING_QUEUE';
+export const ANCHOR_EVENT_JOB = 'ANCHOR_EVENT';
+
+@Injectable()
+export class EventLedgerService {
+  constructor(
+    private readonly prisma: PrismaService,
+    @Inject(ANCHORING_QUEUE)
+    private readonly anchoringQueue: AnchoringQueue,
+  ) {}
+
+  async appendEvent(params: AppendEventParams): Promise<EventLedger> {
+    const event = (await this.prisma.$transaction(async (transaction) => {
+      const tx = transaction as any;
+      const aggregateLockKey = `${params.aggregateType}:${params.aggregateId}`;
+
+      if (typeof tx.$executeRaw !== 'function') {
+        throw new Error(
+          'The database transaction client must support advisory locks for event sequence allocation',
+        );
+      }
+
+      await tx.$executeRaw(
+        Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${aggregateLockKey}, 0))`,
+      );
+
+      const latestEvent = await tx.eventLedger.findFirst({
+        where: {
+          aggregateType: params.aggregateType,
+          aggregateId: params.aggregateId,
+        },
+        orderBy: {
+          sequenceNumber: 'desc',
+        },
+      });
+
+      const sequenceNumber = (latestEvent?.sequenceNumber ?? 0) + 1;
+
+      return tx.eventLedger.create({
+        data: {
+          aggregateType: params.aggregateType,
+          aggregateId: params.aggregateId,
+          sequenceNumber,
+          eventType: params.eventType,
+          payload: params.payload as Prisma.InputJsonValue,
+          recordedBy: params.recordedBy,
+        },
+      });
+    })) as unknown as EventLedger;
+
+    await this.anchoringQueue.add(ANCHOR_EVENT_JOB, {
+      eventId: event.id,
+      aggregateType: event.aggregateType,
+      aggregateId: event.aggregateId,
+      sequenceNumber: event.sequenceNumber,
+    });
+
+    return event;
+  }
+}

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -1,12 +1,41 @@
 import { Global, Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Queue } from 'bullmq';
 import { EventsService } from './events.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import {
+  ANCHORING_QUEUE,
+  EventLedgerService,
+} from '../event-ledger/event-ledger.service';
+import {
+  getRedisConnection,
+  getJobAttempts,
+  getJobBackoffDelay,
+} from '../jobs/queues/queue.config';
 
-@Global() // Makes EventsService available application-wide without needing to import EventsModule everywhere
+@Global()
 @Module({
-  imports: [PrismaModule],
-  providers: [EventsService],
-  exports: [EventsService], // Export it so other modules can use it
+  imports: [PrismaModule, ConfigModule],
+  providers: [
+    EventsService,
+    EventLedgerService,
+    {
+      provide: ANCHORING_QUEUE,
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) =>
+        new Queue(ANCHORING_QUEUE, {
+          connection: getRedisConnection(configService),
+          defaultJobOptions: {
+            attempts: getJobAttempts(configService),
+            backoff: {
+              type: 'fixed',
+              delay: getJobBackoffDelay(configService),
+            },
+          },
+        }),
+    },
+  ],
+  exports: [EventsService, EventLedgerService],
 })
 export class EventsModule {}
 


### PR DESCRIPTION
Closes #126

This PR was generated by the DripTide AI coder and scoped strictly to issue #126.

### Changes
Added EventLedgerService.appendEvent() with transactional per-aggregate sequence allocation protected by a PostgreSQL advisory lock, inserted ledger events, and queued an anchoring job after successful persistence. Registered the service and anchoring BullMQ queue in EventsModule.

### Verification
Passed automated self-review (lint + issue-coverage checks).

_Linked with `Closes #126` so the Drips Wave bot resolves the issue on merge._