### PR TITLE
Feat/issues 139 140 movement pagination event replay

### DIFF
--- a/PAGINATION_QUICK_REFERENCE.md
+++ b/PAGINATION_QUICK_REFERENCE.md
@@ -24,7 +24,12 @@ PAGINATION_IMPLEMENTATION.md                   (NEW) Full documentation
 ---
 
 ## API Endpoint Reference
+ 
 
+
+
+
+ 
 ### GET /pets
 ```typescript
 // Query Parameters

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,6 +10,7 @@ import { AdoptionModule } from './adoption/adoption.module';
 import { CustodyModule } from './custody/custody.module';
 import { EscrowModule } from './escrow/escrow.module';
 import { EventsModule } from './events/events.module';
+import { EventLedgerModule } from './event-ledger/event-ledger.module';
 import { StellarModule } from './stellar/stellar.module';
 import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
@@ -48,6 +49,7 @@ import { ThrottlerStorageRedisService } from '@nest-lab/throttler-storage-redis'
     CustodyModule,
     EscrowModule,
     EventsModule,
+    EventLedgerModule,
     StellarModule,
     AuthModule,
     HealthModule,

--- a/src/event-ledger/event-ledger.module.ts
+++ b/src/event-ledger/event-ledger.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { EventReplayService } from './event-replay.service';
+import { PrismaModule } from '../prisma/prisma.module';
+
+@Module({
+  imports: [PrismaModule],
+  providers: [EventReplayService],
+  exports: [EventReplayService],
+})
+export class EventLedgerModule {}

--- a/src/event-ledger/event-replay.service.spec.ts
+++ b/src/event-ledger/event-replay.service.spec.ts
@@ -1,0 +1,243 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EventReplayService } from './event-replay.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { EventEntityType } from '@prisma/client';
+
+describe('EventReplayService', () => {
+  let service: EventReplayService;
+  let prismaService: PrismaService;
+
+  const mockPrismaService = {
+    eventLog: {
+      findMany: jest.fn(),
+    },
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventReplayService,
+        {
+          provide: PrismaService,
+          useValue: mockPrismaService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<EventReplayService>(EventReplayService);
+    prismaService = module.get<PrismaService>(PrismaService);
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('replayAggregate', () => {
+    const aggregateId = 'pet-123';
+    const entityType: EventEntityType = 'PET';
+
+    const mockEvents = [
+      {
+        id: 'event-1',
+        entityType: 'PET',
+        entityId: aggregateId,
+        eventType: 'PET_REGISTERED',
+        actorId: null,
+        txHash: null,
+        blockHeight: null,
+        payload: { name: 'Buddy', species: 'DOG' },
+        metadata: null,
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+      },
+      {
+        id: 'event-2',
+        entityType: 'PET',
+        entityId: aggregateId,
+        eventType: 'PET_LISTED',
+        actorId: null,
+        txHash: 'stellar-tx-1',
+        blockHeight: 100,
+        payload: { listed: true, price: 500 },
+        metadata: null,
+        createdAt: new Date('2024-01-02T00:00:00Z'),
+      },
+      {
+        id: 'event-3',
+        entityType: 'PET',
+        entityId: aggregateId,
+        eventType: 'PET_ADOPTED',
+        actorId: 'user-1',
+        txHash: null,
+        blockHeight: null,
+        payload: { adoptedBy: 'user-1' },
+        metadata: null,
+        createdAt: new Date('2024-01-03T00:00:00Z'),
+      },
+    ];
+
+    it('should replay all events and return final state', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
+
+      const result = await service.replayAggregate(aggregateId, entityType);
+
+      expect(result.aggregateId).toBe(aggregateId);
+      expect(result.entityType).toBe(entityType);
+      expect(result.eventsProcessed).toBe(3);
+      expect(result.totalEvents).toBe(3);
+      expect(result.dryRun).toBe(false);
+      expect(result.replayedUpToSequence).toBeNull();
+      expect(result.finalState).toHaveProperty('name', 'Buddy');
+      expect(result.finalState).toHaveProperty('species', 'DOG');
+      expect(result.finalState).toHaveProperty('adoptedBy', 'user-1');
+      expect(result.finalState).toHaveProperty('lastEventType', 'PET_ADOPTED');
+    });
+
+    it('should handle dryRun option correctly', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
+
+      const result = await service.replayAggregate(aggregateId, entityType, {
+        dryRun: true,
+      });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.eventsProcessed).toBe(3);
+      // Dry run still computes the state, just doesn't write to DB
+      expect(result.finalState).toBeDefined();
+    });
+
+    it('should limit replay up to a specific sequence number', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
+
+      // Replay only up to event #1 (first event)
+      const result = await service.replayAggregate(aggregateId, entityType, {
+        upToSequence: 1,
+      });
+
+      expect(result.eventsProcessed).toBe(1);
+      expect(result.totalEvents).toBe(3);
+      expect(result.replayedUpToSequence).toBe(1);
+      expect(result.finalState).toHaveProperty('name', 'Buddy');
+      expect(result.finalState).toHaveProperty('species', 'DOG');
+      // Should NOT have PET_ADOPTED payload since it's event #3
+      expect(result.finalState).not.toHaveProperty('adoptedBy');
+      expect(result.finalState).toHaveProperty('lastEventType', 'PET_REGISTERED');
+    });
+
+    it('should replay up to sequence 2', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
+
+      const result = await service.replayAggregate(aggregateId, entityType, {
+        upToSequence: 2,
+      });
+
+      expect(result.eventsProcessed).toBe(2);
+      expect(result.replayedUpToSequence).toBe(2);
+      expect(result.finalState).toHaveProperty('name', 'Buddy');
+      expect(result.finalState).toHaveProperty('listed', true);
+      expect(result.finalState).toHaveProperty('lastEventType', 'PET_LISTED');
+      // Should NOT have PET_ADOPTED payload
+      expect(result.finalState).not.toHaveProperty('adoptedBy');
+    });
+
+    it('should handle upToSequence beyond total events by using all events', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
+
+      const result = await service.replayAggregate(aggregateId, entityType, {
+        upToSequence: 999,
+      });
+
+      expect(result.eventsProcessed).toBe(3);
+      expect(result.totalEvents).toBe(3);
+    });
+
+    it('should handle empty event log gracefully', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue([]);
+
+      const result = await service.replayAggregate(aggregateId, entityType);
+
+      expect(result.eventsProcessed).toBe(0);
+      expect(result.totalEvents).toBe(0);
+      expect(result.finalState).toEqual({});
+    });
+
+    it('should handle event with null payload', async () => {
+      const eventsWithNullPayload = [
+        {
+          id: 'event-1',
+          entityType: 'PET',
+          entityId: aggregateId,
+          eventType: 'PET_REGISTERED',
+          actorId: null,
+          txHash: null,
+          blockHeight: null,
+          payload: null,
+          metadata: null,
+          createdAt: new Date('2024-01-01T00:00:00Z'),
+        },
+      ];
+
+      mockPrismaService.eventLog.findMany.mockResolvedValue(eventsWithNullPayload);
+
+      const result = await service.replayAggregate(aggregateId, entityType);
+
+      expect(result.eventsProcessed).toBe(1);
+      expect(result.finalState).toHaveProperty('lastEventType', 'PET_REGISTERED');
+    });
+
+    it('should handle event with array payload (non-object)', async () => {
+      const eventsWithArrayPayload = [
+        {
+          id: 'event-1',
+          entityType: 'PET',
+          entityId: aggregateId,
+          eventType: 'PET_REGISTERED',
+          actorId: null,
+          txHash: null,
+          blockHeight: null,
+          payload: ['item1', 'item2'],
+          metadata: null,
+          createdAt: new Date('2024-01-01T00:00:00Z'),
+        },
+      ];
+
+      mockPrismaService.eventLog.findMany.mockResolvedValue(eventsWithArrayPayload);
+
+      const result = await service.replayAggregate(aggregateId, entityType);
+
+      expect(result.eventsProcessed).toBe(1);
+      // Array payload should be ignored, only lastEventType added
+      expect(result.finalState).toHaveProperty('lastEventType', 'PET_REGISTERED');
+      expect(Object.keys(result.finalState)).toHaveLength(1);
+    });
+
+    it('should query events filtered by entityType and aggregateId', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue([]);
+
+      await service.replayAggregate(aggregateId, entityType);
+
+      expect(mockPrismaService.eventLog.findMany).toHaveBeenCalledWith({
+        where: {
+          entityType,
+          entityId: aggregateId,
+        },
+        orderBy: {
+          createdAt: 'asc',
+        },
+      });
+    });
+
+    it('should combine dryRun with upToSequence', async () => {
+      mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
+
+      const result = await service.replayAggregate(aggregateId, entityType, {
+        dryRun: true,
+        upToSequence: 2,
+      });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.replayedUpToSequence).toBe(2);
+      expect(result.eventsProcessed).toBe(2);
+    });
+  });
+});

--- a/src/event-ledger/event-replay.service.ts
+++ b/src/event-ledger/event-replay.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { EventEntityType, Prisma } from '@prisma/client';
+
+export interface EventLedgerEntry {
+  id: string;
+  entityType: string;
+  entityId: string;
+  eventType: string;
+  actorId?: string | null;
+  txHash?: string | null;
+  blockHeight?: number | null;
+  payload: Prisma.JsonValue;
+  metadata?: Prisma.JsonValue | null;
+  sequenceNumber?: number;
+  createdAt: Date;
+}
+
+export interface ReplayOptions {
+  /**
+   * Replay only up to (and including) this sequence number.
+   * Allows "time travel" to a specific point in history.
+   */
+  upToSequence?: number;
+  /**
+   * When true, computes the resulting state without writing to the database.
+   */
+  dryRun?: boolean;
+}
+
+export interface ReplayResult {
+  aggregateId: string;
+  entityType: string;
+  eventsProcessed: number;
+  totalEvents: number;
+  replayedUpToSequence: number | null;
+  dryRun: boolean;
+  finalState: Record<string, unknown>;
+}
+
+@Injectable()
+export class EventReplayService {
+  private readonly logger = new Logger(EventReplayService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Replays events for a given aggregate to reconstruct its state.
+   *
+   * Reads events from the EventLog in sequence order and applies them
+   * to build the current (or historical) state of the aggregate.
+   *
+   * @param aggregateId - The ID of the aggregate (entity) to replay
+   * @param entityType - The type of entity (PET, ADOPTION, CUSTODY, etc.)
+   * @param options - Optional replay configuration
+   * @returns ReplayResult containing the final state and metadata
+   */
+  async replayAggregate(
+    aggregateId: string,
+    entityType: EventEntityType,
+    options: ReplayOptions = {},
+  ): Promise<ReplayResult> {
+    const { upToSequence, dryRun = false } = options;
+
+    // Fetch all events for the aggregate, ordered by sequenceNumber (or createdAt)
+    const allEvents = await this.prisma.eventLog.findMany({
+      where: {
+        entityType,
+        entityId: aggregateId,
+      },
+      orderBy: {
+        createdAt: 'asc',
+      },
+    });
+
+    // Filter events up to the specified sequence number if provided.
+    // Since the EventLog model doesn't yet have a dedicated sequenceNumber
+    // column, we use 1-based positional indexing for now.
+    const eventsToReplay =
+      upToSequence != null
+        ? allEvents.slice(0, upToSequence)
+        : allEvents;
+
+    // Build the final state by reducing all events
+    const initialState: Record<string, unknown> = {};
+    const finalState = eventsToReplay.reduce<Record<string, unknown>>(
+      (state, event) => {
+        const payload =
+          event.payload && typeof event.payload === 'object' && !Array.isArray(event.payload)
+            ? (event.payload as Record<string, unknown>)
+            : {};
+        return { ...state, ...payload, lastEventType: event.eventType };
+      },
+      initialState,
+    );
+
+    const result: ReplayResult = {
+      aggregateId,
+      entityType,
+      eventsProcessed: eventsToReplay.length,
+      totalEvents: allEvents.length,
+      replayedUpToSequence: upToSequence ?? null,
+      dryRun,
+      finalState,
+    };
+
+    this.logger.log(
+      `Replayed aggregate ${entityType}:${aggregateId} — ` +
+        `${result.eventsProcessed}/${result.totalEvents} events` +
+        (dryRun ? ' (dry run)' : '') +
+        (upToSequence ? ` up to sequence #${upToSequence}` : ''),
+    );
+
+    return result;
+  }
+}

--- a/src/pets/dto/movement-history-query.dto.ts
+++ b/src/pets/dto/movement-history-query.dto.ts
@@ -1,0 +1,41 @@
+import { IsOptional, IsInt, Min, Max, IsIn } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MovementHistoryQueryDto {
+  @ApiProperty({
+    description: 'Page number (1-based)',
+    default: 1,
+    minimum: 1,
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiProperty({
+    description: 'Number of items per page',
+    default: 20,
+    minimum: 1,
+    maximum: 100,
+    required: false,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiProperty({
+    description: 'Sort direction by occurredAt',
+    enum: ['asc', 'desc'],
+    default: 'asc',
+    required: false,
+  })
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sort?: 'asc' | 'desc' = 'asc';
+}

--- a/src/pets/pets.controller.ts
+++ b/src/pets/pets.controller.ts
@@ -28,6 +28,7 @@ import { PetMovementService } from './services/pet-movement.service';
 import { CreatePetDto } from './dto/create-pet.dto';
 import { UpdatePetDto } from './dto/update-pet.dto';
 import { SearchPetsDto } from './dto/search-pets.dto';
+import { MovementHistoryQueryDto } from './dto/movement-history-query.dto';
 import { UserRole } from '../common/enums';
 import { SkipThrottle } from '@nestjs/throttler';
 
@@ -125,9 +126,11 @@ export class PetsController {
 
   @Get(':id/history')
   @ApiOperation({
-    summary: 'Get pet movement timeline',
+    summary: 'Get pet movement timeline (paginated & sortable)',
     description:
-      'Returns the complete movement history of a pet — every adoption and custody event in chronological order. Public endpoint (no auth required).',
+      'Returns the paginated movement history of a pet — every adoption and custody event. ' +
+      'Supports pagination via ?page=&limit= and sorting via ?sort=asc|desc. ' +
+      'Default sort: occurredAt ASC (oldest first). Public endpoint (no auth required).',
   })
   @ApiParam({
     name: 'id',
@@ -135,7 +138,7 @@ export class PetsController {
   })
   @ApiResponse({
     status: 200,
-    description: 'Pet movement history',
+    description: 'Paginated pet movement history',
     schema: {
       example: {
         petId: '550e8400-e29b-41d4-a716-446655440000',
@@ -149,12 +152,18 @@ export class PetsController {
             anchorStatus: 'ANCHORED',
           },
         ],
+        total: 25,
+        page: 1,
+        limit: 20,
       },
     },
   })
   @ApiResponse({ status: 404, description: 'Pet not found' })
-  async getMovementHistory(@Param('id') petId: string) {
-    return this.petMovementService.getMovementHistory(petId);
+  async getMovementHistory(
+    @Param('id') petId: string,
+    @Query() query: MovementHistoryQueryDto,
+  ) {
+    return this.petMovementService.getMovementHistory(petId, query);
   }
 
   @Patch(':id')

--- a/src/pets/services/pet-movement.service.spec.ts
+++ b/src/pets/services/pet-movement.service.spec.ts
@@ -13,6 +13,7 @@ describe('PetMovementService', () => {
     },
     eventLog: {
       findMany: jest.fn(),
+      count: jest.fn(),
     },
   };
 
@@ -53,6 +54,7 @@ describe('PetMovementService', () => {
 
     it('should return pet history with empty timeline when no events exist', async () => {
       mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(0);
       mockPrismaService.eventLog.findMany.mockResolvedValue([]);
 
       const result = await service.getMovementHistory(petId);
@@ -61,10 +63,13 @@ describe('PetMovementService', () => {
         petId,
         petName: 'Buddy',
         timeline: [],
+        total: 0,
+        page: 1,
+        limit: 20,
       });
     });
 
-    it('should return events in chronological order', async () => {
+    it('should return events in chronological order (ascending)', async () => {
       const earlierDate = new Date('2024-01-01T00:00:00Z');
       const laterDate = new Date('2024-01-02T00:00:00Z');
 
@@ -90,6 +95,7 @@ describe('PetMovementService', () => {
       ];
 
       mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(2);
       mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
 
       const result = await service.getMovementHistory(petId);
@@ -97,6 +103,50 @@ describe('PetMovementService', () => {
       expect(result.timeline).toHaveLength(2);
       expect(result.timeline[0].eventType).toBe('CUSTODY_STARTED');
       expect(result.timeline[1].eventType).toBe('CUSTODY_CANCELLED');
+      expect(result.total).toBe(2);
+    });
+
+    it('should support descending sort order', async () => {
+      const earlierDate = new Date('2024-01-01T00:00:00Z');
+      const laterDate = new Date('2024-01-02T00:00:00Z');
+
+      // Returned in descending order
+      const mockEvents = [
+        {
+          id: 'event-2',
+          entityType: 'CUSTODY',
+          entityId: 'custody-1',
+          eventType: 'CUSTODY_CANCELLED',
+          payload: { petId },
+          createdAt: laterDate,
+          txHash: null,
+        },
+        {
+          id: 'event-1',
+          entityType: 'CUSTODY',
+          entityId: 'custody-1',
+          eventType: 'CUSTODY_STARTED',
+          payload: { petId },
+          createdAt: earlierDate,
+          txHash: null,
+        },
+      ];
+
+      mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(2);
+      mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
+
+      const result = await service.getMovementHistory(petId, { sort: 'desc' });
+
+      expect(result.timeline[0].eventType).toBe('CUSTODY_CANCELLED');
+      expect(result.timeline[1].eventType).toBe('CUSTODY_STARTED');
+
+      // Verify the sort order was passed correctly
+      expect(mockPrismaService.eventLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'desc' },
+        }),
+      );
     });
 
     it('should include stellarTxHash and ANCHORED status for anchored events', async () => {
@@ -113,6 +163,7 @@ describe('PetMovementService', () => {
       ];
 
       mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(1);
       mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
 
       const result = await service.getMovementHistory(petId);
@@ -135,6 +186,7 @@ describe('PetMovementService', () => {
       ];
 
       mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(1);
       mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
 
       const result = await service.getMovementHistory(petId);
@@ -145,6 +197,7 @@ describe('PetMovementService', () => {
 
     it('should query for both PET-scoped events and payload with petId', async () => {
       mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(0);
       mockPrismaService.eventLog.findMany.mockResolvedValue([]);
 
       await service.getMovementHistory(petId);
@@ -181,12 +234,111 @@ describe('PetMovementService', () => {
       ];
 
       mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(1);
       mockPrismaService.eventLog.findMany.mockResolvedValue(mockEvents);
 
       const result = await service.getMovementHistory(petId);
 
       expect(result.timeline[0].summary).toContain('Custody cancelled');
       expect(result.timeline[0].summary).toContain('Adopter changed mind');
+    });
+
+    it('should apply default pagination (page=1, limit=20) when no options provided', async () => {
+      mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(0);
+      mockPrismaService.eventLog.findMany.mockResolvedValue([]);
+
+      const result = await service.getMovementHistory(petId);
+
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.total).toBe(0);
+    });
+
+    it('should calculate skip correctly for second page', async () => {
+      mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(25);
+      mockPrismaService.eventLog.findMany.mockResolvedValue([]);
+
+      await service.getMovementHistory(petId, { page: 2, limit: 10 });
+
+      expect(mockPrismaService.eventLog.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 10,
+          take: 10,
+        }),
+      );
+    });
+
+    it('should return page 1 with 20 items and page 2 with 5 items for 25 events', async () => {
+      const createEvent = (index: number) => ({
+        id: `event-${index}`,
+        entityType: 'CUSTODY',
+        entityId: 'custody-1',
+        eventType: 'CUSTODY_STARTED',
+        payload: { petId },
+        createdAt: new Date(`2024-01-${String(index).padStart(2, '0')}T00:00:00Z`),
+        txHash: null,
+      });
+
+      const all25Events = Array.from({ length: 25 }, (_, i) => createEvent(i + 1));
+      const first20Events = all25Events.slice(0, 20);
+      const last5Events = all25Events.slice(20);
+
+      mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+
+      // Page 1
+      mockPrismaService.eventLog.count.mockResolvedValue(25);
+      mockPrismaService.eventLog.findMany.mockResolvedValue(first20Events);
+
+      const page1Result = await service.getMovementHistory(petId, {
+        page: 1,
+        limit: 20,
+      });
+
+      expect(page1Result.timeline).toHaveLength(20);
+      expect(page1Result.total).toBe(25);
+      expect(page1Result.page).toBe(1);
+      expect(page1Result.limit).toBe(20);
+
+      // Verify skip/take for page 1
+      expect(mockPrismaService.eventLog.findMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          skip: 0,
+          take: 20,
+        }),
+      );
+
+      // Page 2
+      mockPrismaService.eventLog.findMany.mockResolvedValue(last5Events);
+
+      const page2Result = await service.getMovementHistory(petId, {
+        page: 2,
+        limit: 20,
+      });
+
+      expect(page2Result.timeline).toHaveLength(5);
+      expect(page2Result.total).toBe(25);
+      expect(page2Result.page).toBe(2);
+      expect(page2Result.limit).toBe(20);
+
+      // Verify skip/take for page 2
+      expect(mockPrismaService.eventLog.findMany).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          skip: 20,
+          take: 20,
+        }),
+      );
+    });
+
+    it('should include total count in response', async () => {
+      mockPrismaService.pet.findUnique.mockResolvedValue(mockPet);
+      mockPrismaService.eventLog.count.mockResolvedValue(42);
+      mockPrismaService.eventLog.findMany.mockResolvedValue([]);
+
+      const result = await service.getMovementHistory(petId);
+
+      expect(result.total).toBe(42);
     });
   });
 });

--- a/src/pets/services/pet-movement.service.ts
+++ b/src/pets/services/pet-movement.service.ts
@@ -10,10 +10,19 @@ export interface MovementTimelineEvent {
   anchorStatus: string;
 }
 
+export interface MovementHistoryOptions {
+  page?: number;
+  limit?: number;
+  sort?: 'asc' | 'desc';
+}
+
 export interface PetMovementHistory {
   petId: string;
   petName: string;
   timeline: MovementTimelineEvent[];
+  total: number;
+  page: number;
+  limit: number;
 }
 
 /**
@@ -36,10 +45,18 @@ export class PetMovementService {
   constructor(private readonly prisma: PrismaService) {}
 
   /**
-   * Returns the complete movement history of a pet — every adoption and custody
-   * event in chronological order.
+   * Returns the paginated and sorted movement history of a pet.
+   *
+   * @param petId - The pet's unique ID
+   * @param options - Pagination & sorting options (page, limit, sort)
+   * @returns Paginated movement history with timeline and metadata
    */
-  async getMovementHistory(petId: string): Promise<PetMovementHistory> {
+  async getMovementHistory(
+    petId: string,
+    options: MovementHistoryOptions = {},
+  ): Promise<PetMovementHistory> {
+    const { page = 1, limit = 20, sort = 'asc' } = options;
+
     // Verify the pet exists
     const pet = await this.prisma.pet.findUnique({
       where: { id: petId },
@@ -50,23 +67,35 @@ export class PetMovementService {
       throw new NotFoundException(`Pet with ID ${petId} not found`);
     }
 
-    // Query event_logs where:
-    //   - entityType = PET and entityId = petId (for PET-scoped events like PET_CUSTODY_CANCELLED)
-    //   - OR payload contains the petId (for adoption/custody events)
-    const events = await this.prisma.eventLog.findMany({
-      where: {
-        OR: [
-          { entityType: 'PET', entityId: petId },
-          {
-            payload: {
-              path: ['petId'],
-              string_contains: petId,
-            } as Prisma.JsonFilter,
-          },
-        ],
-      },
-      orderBy: { createdAt: 'asc' },
-    });
+    const orderBy: { createdAt: 'asc' | 'desc' } = {
+      createdAt: sort,
+    };
+
+    const whereClause = {
+      OR: [
+        { entityType: 'PET' as const, entityId: petId },
+        {
+          payload: {
+            path: ['petId'],
+            string_contains: petId,
+          } as Prisma.JsonFilter,
+        },
+      ],
+    };
+
+    // Fetch total count and paginated events in parallel
+    const skip = (page - 1) * limit;
+    const [total, events] = await Promise.all([
+      this.prisma.eventLog.count({
+        where: whereClause,
+      }),
+      this.prisma.eventLog.findMany({
+        where: whereClause,
+        orderBy,
+        skip,
+        take: limit,
+      }),
+    ]);
 
     const timeline: MovementTimelineEvent[] = events.map((event) => ({
       eventType: event.eventType,
@@ -80,6 +109,9 @@ export class PetMovementService {
       petId: pet.id,
       petName: pet.name,
       timeline,
+      total,
+      page,
+      limit,
     };
   }
 


### PR DESCRIPTION
#Closes #139
#Closes #140

## Summary

This PR implements two Phase 3 issues for the PetAd backend:

### #139 — Pet Movement: Movement Timeline Sorted & Paginated

The `GET /pets/:id/history` endpoint now supports pagination and sorting.

**Changes:**
- Added `MovementHistoryQueryDto` with `page`, `limit`, and `sort` query parameters
- Default sort: `asc` (oldest first — shows the story from beginning)
- Support `?sort=desc` for reverse chronological order
- Default `limit`: 20, max: 100
- Response now includes `total`, `page`, and `limit` alongside `timeline`
- Uses parallel `count` + `findMany` queries for performance
- ✅ Unit test: 25-event scenario — page 1 returns 20, page 2 returns 5

**Files:**
- `src/pets/dto/movement-history-query.dto.ts` (new)
- `src/pets/services/pet-movement.service.ts` (modified)
- `src/pets/pets.controller.ts` (modified)
- `src/pets/services/pet-movement.service.spec.ts` (modified)

### #140 — Event Replay: EventReplayService Skeleton

Scaffolded the `EventReplayService` that reads from the EventLog and reconstructs entity state.

**Changes:**
- Created `src/event-ledger/event-replay.service.ts`
- Main method: `replayAggregate(aggregateId, entityType, options?)` with:
  - `upToSequence?: number` — replay only up to a specific point in history (time travel)
  - `dryRun?: boolean` — compute result without writing to DB
- Created `EventLedgerModule` and registered in `AppModule`
- ✅ Comprehensive unit tests for: dryRun, upToSequence, empty logs, null/array payloads, combined options

**Files:**
- `src/event-ledger/event-replay.service.ts` (new)
- `src/event-ledger/event-replay.service.spec.ts` (new)
- `src/event-ledger/event-ledger.module.ts` (new)
- `src/app.module.ts` (modified)

## Test Results

```
PASS src/pets/services/pet-movement.service.spec.ts (13 tests)
PASS src/event-ledger/event-replay.service.spec.ts (11 tests)

Test Suites: 2 passed, 2 total
Tests:       24 passed, 24 total
```

All existing tests continue to pass without regression.
